### PR TITLE
Add Tholos destroy

### DIFF
--- a/README.md
+++ b/README.md
@@ -186,6 +186,7 @@ The tool accepts the following parameters:
   -init	Initialize remote S3 bucket and state
   -t  Terraform resources to target only, (-t resourcetype.resource resourcetype2.resource2)
   -u	Fetch and update modules from remote repo
+  -destroy	Terraform destroy
 
 ```
 

--- a/main.go
+++ b/main.go
@@ -64,6 +64,7 @@ func main() {
 	initPtr := flag.Bool("init", false, "Initialize project S3 bucket state")
 	modulesPtr := flag.Bool("u", false, "Fetch and update modules from remote repo")
 	outputsPtr := flag.Bool("o", false, "Display Terraform outputs")
+	destroyPtr := flag.Bool("destroy", false, "Terraform Destroy")
 	envPtr := flag.String("e", "", "Terraform state environment to use")
 	flag.Var(&targetsTF, "t", "Terraform resources to target only, (-t resourcetype.resource resourcetype2.resource2)")
 
@@ -74,7 +75,7 @@ func main() {
 		Tf_modules_dir:      "tfmodules",
 	}
 
-	if !*planPtr && !*initPtr && !*modulesPtr && !*outputsPtr && !*applyPtr {
+	if !*planPtr && !*initPtr && !*modulesPtr && !*outputsPtr && !*applyPtr && !*destroyPtr {
 		fmt.Println("Please provide one of the following parameters:")
 		flag.PrintDefaults()
 		os.Exit(0)
@@ -269,6 +270,8 @@ func main() {
 		state_config.Outputs()
 	} else if *applyPtr {
 		state_config.Apply()
+	} else if *destroyPtr {
+		state_config.Destroy(tf_parallelism)
 	}
 
 }

--- a/tf_helper/destroy.go
+++ b/tf_helper/destroy.go
@@ -1,0 +1,48 @@
+package tf_helper
+
+import (
+	"bufio"
+	"fmt"
+	"log"
+	"os"
+	"strings"
+)
+
+func (c *Config) Destroy(parallelism int16) {
+
+	//We want to really ensure destroy is what you want to do, therefore we double check here, requiring an input from CLI
+
+	reader := bufio.NewReader(os.Stdin)
+
+	fmt.Println("You are running Destroy! Are you sure you want to proceed? Confirm by entering Destroy: ")
+
+	input, _ := reader.ReadString('\n')
+
+	if strings.TrimRight(strings.ToLower(input), "\n") == "destroy" {
+
+		log.Println("[INFO] Proceeding with Terraform destroy.")
+
+	} else {
+
+		log.Println("[INFO] Not proceeding with Terraform destroy.")
+		os.Exit(1)
+
+	}
+
+	cmd_name := "terraform"
+
+	exec_args := []string{"destroy", fmt.Sprintf("-parallelism=%d", parallelism)}
+
+	if len(c.TargetsTF) > 0 {
+		for _, t := range c.TargetsTF {
+			exec_args = append(exec_args, fmt.Sprintf("-target=%s", t))
+		}
+	}
+
+	exec_args = append(exec_args, "-auto-approve")
+
+	if !ExecCmd(cmd_name, exec_args) {
+		log.Fatal("[ERROR] Failed to run Terraform destroy. Aborting.")
+	}
+
+}


### PR DESCRIPTION
This PR is for the add_destroy branch which adds the new "Tholos -destroy" flag. The main.go code has been updated to accept a new flag named "destroy", as well as tf_helper/destroy.go has been added, which handles the destroy flag. It includes an intention check to ensure the user wants to run this flag by requiring a CLI input. This branch is branched off of the tf_012_support branch. It has been compiled locally and successully used to run tholos -p & tholos -a, and tholos -destroy to then tear down the the infrastructure again.