### PR TITLE
Added Console, graph and validate to Tholos for Terraform

### DIFF
--- a/README.md
+++ b/README.md
@@ -187,6 +187,9 @@ The tool accepts the following parameters:
   -t  Terraform resources to target only, (-t resourcetype.resource resourcetype2.resource2)
   -u	Fetch and update modules from remote repo
   -destroy	Terraform destroy
+  -c	Terraform Console
+  -v	Terraform Validate ('-type json' for JSON output)
+  -g	Terraform Graph (Optional: Type of graph output: '-type plan|plan-destroy|-apply|refresh|validate'. Max module depth: '-type n', where n is numeric. Highlight cycles with coloured edges: '-type cycles'). Run 'tholos -g <parameters> | tail +3 > output', then use dot (via GraphViz) to convert into an svg file: 'dot -Tsvg output > graph.svg'
 
 ```
 

--- a/main.go
+++ b/main.go
@@ -43,6 +43,7 @@ func (d *multiflag) Set(value string) error {
 }
 
 var targetsTF multiflag
+var typeTF multiflag
 
 const CLR_0 = "\x1b[30;1m"
 const CLR_R = "\x1b[31;1m"
@@ -65,8 +66,12 @@ func main() {
 	modulesPtr := flag.Bool("u", false, "Fetch and update modules from remote repo")
 	outputsPtr := flag.Bool("o", false, "Display Terraform outputs")
 	destroyPtr := flag.Bool("destroy", false, "Terraform Destroy")
+	consolePtr := flag.Bool("c", false, "Terraform Console")
+	validatePtr := flag.Bool("v", false, "Terraform Validate")
+	graphPtr := flag.Bool("g", false, "Terraform Graph")
 	envPtr := flag.String("e", "", "Terraform state environment to use")
 	flag.Var(&targetsTF, "t", "Terraform resources to target only, (-t resourcetype.resource resourcetype2.resource2)")
+	flag.Var(&typeTF, "type", "Terraform additional options for validate and graph")
 
 	flag.Parse()
 
@@ -75,7 +80,7 @@ func main() {
 		Tf_modules_dir:      "tfmodules",
 	}
 
-	if !*planPtr && !*initPtr && !*modulesPtr && !*outputsPtr && !*applyPtr && !*destroyPtr {
+	if !*planPtr && !*initPtr && !*modulesPtr && !*outputsPtr && !*applyPtr && !*destroyPtr && !*consolePtr && !*validatePtr && !*graphPtr {
 		fmt.Println("Please provide one of the following parameters:")
 		flag.PrintDefaults()
 		os.Exit(0)
@@ -188,6 +193,7 @@ func main() {
 		TFlegacy:         tf_legacy,
 		TFLockLegacy:     tf_lock_legacy,
 		TFenv:            *envPtr,
+		TypeTF:           typeTF,
 	}
 
 	var tf_parallelism int16 = 10
@@ -272,6 +278,12 @@ func main() {
 		state_config.Apply()
 	} else if *destroyPtr {
 		state_config.Destroy(tf_parallelism)
+	} else if *consolePtr {
+		state_config.Console()
+	} else if *validatePtr {
+		state_config.Validate()
+	} else if *graphPtr {
+		state_config.Graph()
 	}
 
 }

--- a/tf_helper/console.go
+++ b/tf_helper/console.go
@@ -1,0 +1,27 @@
+package tf_helper
+
+import (
+	"log"
+	"os/exec"
+	"strings"
+)
+
+func (c *Config) Console() {
+
+	//finding terraform as may be different per client
+
+	cmd := exec.Command("which", "terraform")
+
+	cmd_path, err := cmd.Output()
+
+	if err != nil {
+		log.Printf("Error finding terraform executable: %s, err")
+	}
+
+	exec_args := []string{"terraform", "console"}
+
+	if !ExecOsCmd(strings.TrimRight(string(cmd_path), "\n"), exec_args) {
+		log.Fatal("[ERROR] Failed to run Terraform Console. Aborting.")
+	}
+
+}

--- a/tf_helper/exec.go
+++ b/tf_helper/exec.go
@@ -4,6 +4,7 @@ import (
 	"bufio"
 	"fmt"
 	"log"
+	"os"
 	"os/exec"
 	"strings"
 )
@@ -56,4 +57,31 @@ func ExecCmd(cmdName string, args []string) bool {
 
 	return success
 
+}
+
+func ExecOsCmd(cmdPath string, args []string) bool {
+
+	success := true
+
+	log.Printf("[INFO] Executing command: %s", strings.Join(args, " "))
+
+	pa := os.ProcAttr{
+		Files: []*os.File{os.Stdin, os.Stdout, os.Stderr},
+	}
+
+	proc, err := os.StartProcess(cmdPath, args, &pa)
+	if err != nil {
+		success = false
+		log.Printf("Error starting process, Path: %s, Args: %s, Error: %s", cmdPath, args, err)
+	}
+
+	state, err := proc.Wait()
+	if err != nil {
+		success = false
+		log.Printf("Error creating process wait: %s", err)
+	}
+
+	log.Printf("<< Exited console :%s\n", state.String())
+
+	return success
 }

--- a/tf_helper/graph.go
+++ b/tf_helper/graph.go
@@ -1,0 +1,34 @@
+package tf_helper
+
+import (
+	"fmt"
+	"log"
+	"strconv"
+)
+
+func (c *Config) Graph() {
+
+	cmd_name := "terraform"
+
+	exec_args := []string{"graph"}
+
+	log.Println("[INFO] Executing Terraform graph.")
+
+	if len(c.TypeTF) > 0 {
+		for _, t := range c.TypeTF {
+			if t == "cycles" {
+				exec_args = append(exec_args, "-draw-cycles")
+			} else if _, err := strconv.Atoi(t); err == nil {
+				exec_args = append(exec_args, fmt.Sprintf("-module-depth=%s", t))
+			} else if t == "plan-destroy" || t == "apply" || t == "validate" || t == "refresh" {
+				exec_args = append(exec_args, fmt.Sprintf("-type=%s", t))
+			}
+		}
+	}
+
+	if !ExecCmd(cmd_name, exec_args) {
+		log.Fatal("[ERROR] Failed to execute Terraform validate. Aborting.")
+	} else {
+		log.Println("[INFO] Graph creation complete. Use a program like GraphViz to generate an svg file out of the raw data, e.g. through '$ dot -Tsvg output > graph.svg'")
+	}
+}

--- a/tf_helper/state.go
+++ b/tf_helper/state.go
@@ -25,6 +25,7 @@ type Config struct {
 	TFLockLegacy     bool
 	TFenv            string
 	Region           string
+	TypeTF           []string
 }
 
 func (c *Config) Create_bucket(client interface{}) bool {

--- a/tf_helper/validate.go
+++ b/tf_helper/validate.go
@@ -1,0 +1,26 @@
+package tf_helper
+
+import (
+	"log"
+)
+
+func (c *Config) Validate() {
+
+	cmd_name := "terraform"
+
+	exec_args := []string{"validate"}
+
+	log.Println("[INFO] Executing Terraform validate.")
+
+	if len(c.TypeTF) > 0 {
+		for _, t := range c.TypeTF {
+			if t == "json" {
+				exec_args = append(exec_args, "-json")
+			}
+		}
+	}
+
+	if !ExecCmd(cmd_name, exec_args) {
+		log.Fatal("[ERROR] Failed to execute Terraform validate. Aborting.")
+	}
+}


### PR DESCRIPTION
This pull request is to add console, graph and validate from Terraform to Tholos. For both Graph and Validate an additional multiflag, typeTF, has been added to be used for additional options to pass on, to keep those separate from the original multiflag targetTF. A new exec function has been added in order to be able to run an interactive shell.